### PR TITLE
Task6

### DIFF
--- a/task6
+++ b/task6
@@ -1,1 +1,42 @@
+use strict;
+use warnings;
 
+#путь
+my $conf_path = '/Users/evgenijtretakov/PerlProject/tasks/resolved/conf.ini';
+
+sub _read_config {
+    my ( $filename ) = @_;
+
+    my %config;#хэш для хранения значений
+
+    if ( open my $fh, '<', $filename ) {
+        while ( my $line = <$fh> ) {
+            chomp $line;
+            $line =~ s/\s+//g;  # пробелы на пустоту
+
+            if ( $line =~ m/^#/ ) {  # проверяем, если строка начинается с # то пропустим строку
+                next;  
+            }
+
+            my ( $key, $value ) = split( '=', $line, 2 );# разделяем строку по символу = и сохраняем $key и $value
+
+            if ( $key && $value ) {  # проверяем, что ключ и значение не пустые
+                $config{$key} = $value; #сохраняем ключ $key и значение $value в хэше %config
+            }
+        }
+        close $fh; #закрываем файл
+    } else {
+        print "Не удалось считать файл: '$filename'\n";
+    }
+
+    return %config;
+}
+
+# чтение файла конфигурации
+my %conf = _read_config( $conf_path );
+
+# вывод содержимого файла
+foreach my $key ( keys %conf ) {
+    my $value = $conf{$key};
+    print "$key = $value\n";
+}


### PR DESCRIPTION
Преобразование массива в хэш. Регуляные выражения.

Задача:
Модифицировать ф-цию read_conf, чтобы она вернула не массив, а хэш.

Описание:
Глядя на конфиг, само собой напрашивается вернуть хэш, а не массив. Но давайте усложним ситуацию и представим,
 что конфигурационный файл правил не очень ответственный сотрудник и навставлял туда пробелов, табов, а где-то даже
  забыл указать ключ или значение. В результате нужно не просто разбить строку user=passwd на ключ и значение и
  закинуть в хэш, а хорошенько с ней поработать. Тут нам на помощь придут регулярные выражения(РВ). Да, на перный
  взгляд они будут казаться сложными(Незря по ним есть целая толстая книга). Я их вообще ненавидел, но потом, когда
  разобрался, понял всю полезность и мощь!
Прочитайте по ним главу в книге и выполните задания. Если сделали, давайте приступим:
1.Сразу облегчим себе жизнь и с помощью РВ заменим все пробелы на пустоту.
2. Разбив строку на ключ и значение, нужно их проверить на true и если хоть один из них пустой, в хэш эта пара не попадает(ругаться на это не нужно просто пропускаем строку и идем к следующей)
3. Вишенка на торте. Если видели конфигурационный файл crontab(служба запускающая скрипты по расписанию) то могли заметить, что некоторые задания закомментированы символом #. Это значит, что его приостановили на неопределенный срок и crontab его игнорирует. Так вот давайте сделаем это и в нашем конфиге. Если первый симвом #, то пропускаем строку. Делаете это опять же с помощью РВ.
4. После написание ф-ции замените хэш из ф-ции _check_user на хэш полученный из файла.

Подсказка:
Строку можно разбить одной известной командой split, а можно немного покопать и с помощью РВ одним махом проверить формат строки и получить ключ и значение ;)

Полезные привычки:
Обязательно ставьте символ 'm' при поиске по РВ. Например if( $str =~m/\s/ ){} Символ =~ итак вроде указывает на РВ, но perl critic(мы до него дойдем) ругается матом на отсутсвие 'm', ибо так нагляднее и я с ним согласен.